### PR TITLE
LPAL-422 pull in govuk assets when installing flask front

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 **__pycache__
 *.egg-info
+govuk_components/
+flaskfront/opgflaskfront/static/

--- a/flaskfront/MANIFEST.in
+++ b/flaskfront/MANIFEST.in
@@ -1,1 +1,2 @@
 include opgflaskfront/templates/*
+include opgfeedbackfront/static/*

--- a/flaskfront/MANIFEST.in
+++ b/flaskfront/MANIFEST.in
@@ -1,2 +1,2 @@
 include opgflaskfront/templates/*
-include opgfeedbackfront/static/*
+include opgflaskfront/static/*

--- a/flaskfront/build.sh
+++ b/flaskfront/build.sh
@@ -1,0 +1,15 @@
+curl -L https://github.com/alphagov/govuk-frontend/releases/download/v3.14.0/release-v3.14.0.zip > govuk_frontend.zip
+rm -rf opgflaskfront/static
+unzip -o govuk_frontend.zip -d opgflaskfront/static
+mv opgflaskfront/static/assets/* opgflaskfront/static
+rm -rf opgflaskfront/static/assets
+rm -rf govuk_frontend.zip
+
+curl -L https://github.com/alphagov/govuk-frontend/archive/v3.14.0.zip > govuk_frontend_source.zip
+unzip -o govuk_frontend_source.zip -d govuk_frontend_source
+rm -rf govuk_components
+mkdir govuk_components
+mv govuk_frontend_source/govuk-frontend-3.14.0/package/govuk/components/** govuk_components
+find govuk_components -type f ! -name 'fixtures.json' -delete
+rm -rf govuk_frontend_source
+rm -rf govuk_frontend_source.zip

--- a/flaskfront/opgflaskfront/__init__.py
+++ b/flaskfront/opgflaskfront/__init__.py
@@ -65,8 +65,8 @@ def create_flask_app(name: str, force_https=True, loaders=[]) -> Flask:
 
 
 def not_found(error):
-    return render_template("opgflaskfront/404.html"), 404
+    return render_template("404.html"), 404
 
 
 def internal_server_error(error):
-    return render_template("opgflaskfront/500.html"), 500
+    return render_template("500.html"), 500

--- a/flaskfront/setup.py
+++ b/flaskfront/setup.py
@@ -1,5 +1,9 @@
 from setuptools import setup, find_packages
 
+import subprocess
+
+subprocess.call(["sh", "build.sh"])
+
 setup(
     name="opgflaskfront",
     version="1.0",

--- a/flaskfront/tests/test_create_flask_app.py
+++ b/flaskfront/tests/test_create_flask_app.py
@@ -32,5 +32,6 @@ def test_create_flask_app_passing_in_loader():
     response = app.test_client().get("/assets/govuk-frontend-3.14.0.min.js")
     assert response.status_code == 200
 
+    # ensure we get a working 404 not any breakage or a 500
     response = app.test_client().get("/does-not-exist")
     assert response.status_code == 404

--- a/flaskfront/tests/test_create_flask_app.py
+++ b/flaskfront/tests/test_create_flask_app.py
@@ -31,3 +31,6 @@ def test_create_flask_app_passing_in_loader():
 
     response = app.test_client().get("/assets/govuk-frontend-3.14.0.min.js")
     assert response.status_code == 200
+
+    response = app.test_client().get("/does-not-exist")
+    assert response.status_code == 404

--- a/flaskfront/tests/test_create_flask_app.py
+++ b/flaskfront/tests/test_create_flask_app.py
@@ -25,3 +25,9 @@ def test_create_flask_app_passing_in_loader():
 
     response = app.test_client().get("/healthcheck")
     assert response.status_code == 200
+
+    response = app.test_client().get("/assets/govuk-frontend-3.14.0.min.css")
+    assert response.status_code == 200
+
+    response = app.test_client().get("/assets/govuk-frontend-3.14.0.min.js")
+    assert response.status_code == 200


### PR DESCRIPTION
- Use the build.sh from Land Reg's demo to pull in the necessary assets
- Run this script from setup.py
- Tests ensure that specific css and js get a 200 response